### PR TITLE
Set up Jenkins' Coverage & Configure all-contributors bot & Add Badges   

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,17 +1,74 @@
 {
-  "files": ["README.md"],
-  "imageSize": 100,
-  "contributorsPerLine": 7,
-  "contributorsSortAlphabetically": false,
-  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
-  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
-  "types": {
-    "custom": {
-      "symbol": "🔭",
-      "description": "A custom contribution type.",
-      "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
-    }
-  },
-  "skipCi": "false",
-  "contributors": [CostantinoGrana,prittt,stal12,MicheleCancilla,lauracanalini]
+	"projectName": "ecvl",
+	"projectOwner": "AImageLab",
+	"files": [
+		"README.md"
+	],
+	"imageSize": 100,
+	"contributorsPerLine": 7,
+	"contributorsSortAlphabetically": false,
+	"badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+	"contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+	"skipCi": "false",
+	"contributors": [{
+			"login": "prittt",
+			"name": "Federico Bolelli",
+			"avatar_url": "https://avatars.githubusercontent.com/u/6863130?v=1",
+			"profile": "https://github.com/prittt",
+			"contributions": [
+				"dev",
+				"doc",
+				"review",
+				"tool"
+			]
+		},
+		{
+			"login": "lauracanalini",
+			"name": "Laura Canalini",
+			"avatar_url": "https://avatars.githubusercontent.com/u/44258837?v=1",
+			"profile": "https://github.com/lauracanalini",
+			"contributions": [
+				"dev",
+				"doc",
+				"review",
+				"tool"
+			]
+		},
+		{
+			"login": "MicheleCancilla",
+			"name": "Michele Cancilla",
+			"avatar_url": "https://avatars2.githubusercontent.com/u/22983812?v=1",
+			"profile": "https://github.com/MicheleCancilla",
+			"contributions": [
+				"dev",
+				"doc",
+				"review",
+				"tool"
+			]
+		},
+		{
+			"login": "stal12",
+			"name": "Stefano Allegretti",
+			"avatar_url": "https://avatars2.githubusercontent.com/u/34423515?v=1",
+			"profile": "https://github.com/stal12",
+			"contributions": [
+				"dev",
+				"doc",
+				"review",
+				"tool"
+			]
+		},
+		{
+			"login": "CostantinoGrana",
+			"name": "Costantino Grana",
+			"avatar_url": "https://avatars2.githubusercontent.com/u/18437151?v=1",
+			"profile": "https://github.com/CostantinoGrana",
+			"contributions": [
+				"dev",
+				"doc",
+				"review",
+				"tool"
+			]
+		}
+	]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -70,5 +70,6 @@
 				"tool"
 			]
 		}
-	]
+	],
+	"repoType": "github"
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -11,13 +11,34 @@
 	"contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
 	"skipCi": "false",
 	"contributors": [{
+			"login": "CostantinoGrana",
+			"name": "Costantino Grana",
+			"avatar_url": "https://avatars2.githubusercontent.com/u/18437151?v=1",
+			"profile": "https://github.com/CostantinoGrana",
+			"contributions": [
+				"code",
+				"ideas",
+				"tool"
+			]
+		},
+		{
 			"login": "prittt",
 			"name": "Federico Bolelli",
 			"avatar_url": "https://avatars.githubusercontent.com/u/6863130?v=1",
 			"profile": "https://github.com/prittt",
 			"contributions": [
-				"dev",
+				"code",
 				"doc",
+				"tool"
+			]
+		},
+		{
+			"login": "MicheleCancilla",
+			"name": "Michele Cancilla",
+			"avatar_url": "https://avatars2.githubusercontent.com/u/22983812?v=1",
+			"profile": "https://github.com/MicheleCancilla",
+			"contributions": [
+				"code",
 				"review",
 				"tool"
 			]
@@ -28,22 +49,9 @@
 			"avatar_url": "https://avatars.githubusercontent.com/u/44258837?v=1",
 			"profile": "https://github.com/lauracanalini",
 			"contributions": [
-				"dev",
-				"doc",
+				"code",
 				"review",
-				"tool"
-			]
-		},
-		{
-			"login": "MicheleCancilla",
-			"name": "Michele Cancilla",
-			"avatar_url": "https://avatars2.githubusercontent.com/u/22983812?v=1",
-			"profile": "https://github.com/MicheleCancilla",
-			"contributions": [
-				"dev",
-				"doc",
-				"review",
-				"tool"
+				"example"
 			]
 		},
 		{
@@ -52,21 +60,8 @@
 			"avatar_url": "https://avatars2.githubusercontent.com/u/34423515?v=1",
 			"profile": "https://github.com/stal12",
 			"contributions": [
-				"dev",
-				"doc",
-				"review",
-				"tool"
-			]
-		},
-		{
-			"login": "CostantinoGrana",
-			"name": "Costantino Grana",
-			"avatar_url": "https://avatars2.githubusercontent.com/u/18437151?v=1",
-			"profile": "https://github.com/CostantinoGrana",
-			"contributions": [
-				"dev",
-				"doc",
-				"review",
+				"code",
+				"infra",
 				"tool"
 			]
 		}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,17 @@
+{
+  "files": ["README.md"],
+  "imageSize": 100,
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "types": {
+    "custom": {
+      "symbol": "🔭",
+      "description": "A custom contribution type.",
+      "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
+    }
+  },
+  "skipCi": "false",
+  "contributors": [CostantinoGrana,prittt,stal12,MicheleCancilla,lauracanalini]
+}

--- a/DEVSTAT.md
+++ b/DEVSTAT.md
@@ -1,0 +1,68 @@
+
+# ECVL Development Status
+
+:heavy_check_mark: Implemented &nbsp; &nbsp; :large_blue_circle: Scheduled/Work in progress &nbsp; &nbsp; :x: Not implemented &nbsp; &nbsp; :no_entry_sign: Not needed
+
+## Image Read
+| Functionality | CPU | GPU | FPGA |
+|--|--|--|--|
+| Standard Formats | :heavy_check_mark: | :x: | :x: |
+| NIfTI | :heavy_check_mark: | :x: | :x: |
+| DICOM | :heavy_check_mark: | :x: | :x: |
+| Whole-slide image <br>(Hamamatsu, Aperio, MIRAX, ...) | :heavy_check_mark: | :x: | :x: |
+
+## Image Write
+| Functionality | CPU | GPU | FPGA |
+|--|--|--|--|
+| Standard Formats | :heavy_check_mark: | :x: | :x: |
+| NIfTI | :heavy_check_mark: | :x: | :x: |
+| DICOM | :heavy_check_mark: | :x: | :x: |
+
+## Image Arithmetics
+| Functionality | CPU | GPU | FPGA |
+|--|--|--|--|
+| Add | :heavy_check_mark: | :x: | :x: |
+| Sub | :heavy_check_mark: | :x: | :x: |
+| Mul | :heavy_check_mark: | :x: | :x: |
+| Div | :heavy_check_mark: | :x: | :x: |
+| Neg | :heavy_check_mark: | :x: | :x: |
+
+## Image Manipulation
+| Functionality | CPU | GPU | FPGA |
+|--|--|--|--|
+| ChangeColorSpace | :heavy_check_mark: | :x: | :x: |
+| Flip | :heavy_check_mark: | :x: | :x: |
+| HConcat | :heavy_check_mark: | :x: | :x: |
+| Mirror | :heavy_check_mark: | :x: | :x: |
+| ResizeDim | :heavy_check_mark: | :x: | :x: |
+| ResizeScale | :heavy_check_mark: | :x: | :x: |
+| Rotate | :heavy_check_mark: | :x: | :x: |
+| RotateFullImage | :heavy_check_mark: | :x: | :x: |
+| Stack | :heavy_check_mark: | :x: | :x: |
+| VConcat | :heavy_check_mark: | :x: | :x: |
+
+## Pre- Post-processing and Augmentation
+| Functionality | CPU | GPU | FPGA |
+|--|--|--|--|
+| Additive Gaussian Noise | :x: | :x: | :x: |
+| Additive Laplace Noise | :heavy_check_mark: | :x: | :x: |
+| Additive Poisson Noise | :heavy_check_mark: | :x: | :x: |
+| Average Blur | :x: | :x: | :x: |
+| Channel Shuffle | :x: | :x: | :x: |
+| Coarse Dropout | :heavy_check_mark: | :x: | :x: |
+| Connected Components Labeling | :heavy_check_mark: | :x: | :x: |
+| Dropout | :x: | :x: | :x: |
+| Filter2D | :heavy_check_mark: | :x: | :x: |
+| FindContours | :heavy_check_mark: | :x: | :x: |
+| Gamma Contrast | :heavy_check_mark: | :x: | :x: |
+| Gaussian Blur | :heavy_check_mark: | :x: | :x: |
+| Histogram Equalization | :x: | :x: | :x: |
+| Impulse Noise | :x: | :x: | :x: |
+| Integral Image | :heavy_check_mark: | :x: | :x: |
+| Median Blur | :x: | :x: | :x: |
+| Non Maxima Suppression | :heavy_check_mark: | :x: | :x: |
+| Pepper | :x: | :x: | :x: |
+| Salt | :x: | :x: | :x: |
+| Salt And Pepper | :x: | :x: | :x: |
+| SeparableFilter2D | :heavy_check_mark: | :x: | :x: |
+| Threshold | :heavy_check_mark: | :x: | :x: |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,16 @@ pipeline {
                                 }
                             }
                         }
+                        stage('Coverage') {
+                            steps {
+                                timeout(15) {
+                                    echo 'Calculating coverage..'
+                                    bat '"C:/Program Files/OpenCppCoverage/OpenCppCoverage.exe" --source %cd% --export_type=cobertura -- "build/Debug/ECVL_TESTS.exe"'
+									cobertura coberturaReportFile: 'ECVL_TESTSCoverage.xml'
+									bat 'codecov.exe -f ECVL_TESTSCoverage.xml'
+                                }
+                            }
+                        }
                         stage('windows_end') {
                             steps {
                                 echo 'Success!'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,8 @@ pipeline {
                                 timeout(15) {
                                     echo 'Calculating coverage..'
                                     bat '"C:/Program Files/OpenCppCoverage/OpenCppCoverage.exe" --source %cd% --export_type=cobertura -- "build/Debug/ECVL_TESTS.exe"'
-									cobertura coberturaReportFile: 'ECVL_TESTSCoverage.xml'
-									bat 'codecov.exe -f ECVL_TESTSCoverage.xml'
+				    cobertura coberturaReportFile: 'ECVL_TESTSCoverage.xml'
+	   			    bat '"C:/ProgramData/chocolatey/bin/codecov.exe" -f ECVL_TESTSCoverage.xml' -t 7635bd2e-51cf-461e-bb1b-fc7ba9fb26d1
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                                     echo 'Calculating coverage..'
                                     bat '"C:/Program Files/OpenCppCoverage/OpenCppCoverage.exe" --source %cd% --export_type=cobertura -- "build/Debug/ECVL_TESTS.exe"'
 				    cobertura coberturaReportFile: 'ECVL_TESTSCoverage.xml'
-	   			    bat '"C:/ProgramData/chocolatey/bin/codecov.exe" -f ECVL_TESTSCoverage.xml' -t 7635bd2e-51cf-461e-bb1b-fc7ba9fb26d1
+	   			    bat '"C:/ProgramData/chocolatey/bin/codecov.exe" -f ECVL_TESTSCoverage.xml -t 7635bd2e-51cf-461e-bb1b-fc7ba9fb26d1'
                                 }
                             }
                         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 ![ECVL](doc/logo/DEEPHEALTH_doxygen_logo_reduced.png)
 # ECVL - European Computer Vision Library 
+![GitHub release](https://img.shields.io/github/v/release/deephealthproject/ecvl)
 [![codecov](https://codecov.io/gh/deephealthproject/ecvl/branch/master/graph/badge.svg)](https://codecov.io/gh/deephealthproject/ecvl)
 [![License](https://img.shields.io/apm/l/vim-mode)](https://github.com/deephealthproject/ecvl/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # ECVL - European Computer Vision Library 
 ![release](https://img.shields.io/github/v/release/deephealthproject/ecvl)
 [![docs](https://readthedocs.org/projects/pip/badge/?version=latest&style=flat)](https://deephealthproject.github.io/ecvl/)
+![cobertura](https://img.shields.io/jenkins/coverage/cobertura?jobUrl=https%3A%2F%2Fjenkins-master-deephealth-unix01.ing.unimore.it%2Fjob%2FDeepHealth%2Fjob%2Fecvl%2Fjob%2Fbadges%2F&label=cobertura)
 [![codecov](https://codecov.io/gh/deephealthproject/ecvl/branch/master/graph/badge.svg)](https://codecov.io/gh/deephealthproject/ecvl)
 [![License](https://img.shields.io/apm/l/vim-mode)](https://github.com/deephealthproject/ecvl/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![ECVL](doc/logo/DEEPHEALTH_doxygen_logo_reduced.png)
 # ECVL - European Computer Vision Library 
 [![codecov](https://codecov.io/gh/deephealthproject/ecvl/branch/master/graph/badge.svg)](https://codecov.io/gh/deephealthproject/ecvl)
+[![License](https://img.shields.io/apm/l/vim-mode)](https://github.com/deephealthproject/ecvl/blob/master/LICENSE)
 
 | System  |  Compiler  | OpenCV | Status | 
 |:-------:|:----------:|:------:|:------:|

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 ![ECVL](doc/logo/DEEPHEALTH_doxygen_logo_reduced.png)
 # ECVL - European Computer Vision Library 
-![GitHub release](https://img.shields.io/github/v/release/deephealthproject/ecvl)
+![release](https://img.shields.io/github/v/release/deephealthproject/ecvl)
+[![docs](https://readthedocs.org/projects/pip/badge/?version=latest&style=flat)](https://deephealthproject.github.io/ecvl/)
 [![codecov](https://codecov.io/gh/deephealthproject/ecvl/branch/master/graph/badge.svg)](https://codecov.io/gh/deephealthproject/ecvl)
 [![License](https://img.shields.io/apm/l/vim-mode)](https://github.com/deephealthproject/ecvl/blob/master/LICENSE)
 
@@ -15,7 +16,7 @@
 
 ## Documentation
 
-The ECVL documentation is available online [here](https://deephealthproject.github.io/ecvl/). It is automatically updated at each commit/push to the master branch.
+The ECVL documentation is available online [here](https://deephealthproject.github.io/ecvl/).
 
 ## Requirements
 - CMake 3.13 or later

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # ECVL - European Computer Vision Library 
 ![release](https://img.shields.io/github/v/release/deephealthproject/ecvl)
 [![docs](https://readthedocs.org/projects/pip/badge/?version=latest&style=flat)](https://deephealthproject.github.io/ecvl/)
-![cobertura](https://img.shields.io/jenkins/coverage/cobertura?jobUrl=https%3A%2F%2Fjenkins-master-deephealth-unix01.ing.unimore.it%2Fjob%2FDeepHealth%2Fjob%2Fecvl%2Fjob%2Fbadges%2F&label=cobertura)
+![cobertura](https://img.shields.io/jenkins/coverage/cobertura?jobUrl=https%3A%2F%2Fjenkins-master-deephealth-unix01.ing.unimore.it%2Fjob%2FDeepHealth%2Fjob%2Fecvl%2Fjob%2Fmaster%2F&label=cobertura)
 [![codecov](https://codecov.io/gh/deephealthproject/ecvl/branch/master/graph/badge.svg)](https://codecov.io/gh/deephealthproject/ecvl)
 [![License](https://img.shields.io/apm/l/vim-mode)](https://github.com/deephealthproject/ecvl/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ ECVL development status is available [here](DEVSTAT.md).
 
 Any contribution is really welcome!
 
-## Contributors ✨
+## Contributors
 
-The [Emoji Contribution Key](https://allcontributors.org/docs/en/emoji-key) can be found on [allcontributors.org](https://allcontributors.org)
+Thanks goes to these wonderful people ([emoji key](https://github.com/all-contributors/all-contributors#emoji-key)):
 
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 ![ECVL](doc/logo/DEEPHEALTH_doxygen_logo_reduced.png)
 # ECVL - European Computer Vision Library 
+[![codecov](https://codecov.io/gh/deephealthproject/ecvl/branch/master/graph/badge.svg)](https://codecov.io/gh/deephealthproject/ecvl)
 
 | System  |  Compiler  | OpenCV | Status | 
 |:-------:|:----------:|:------:|:------:|

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Documentation
 
-The ECVL documentation is available online [here](https://deephealthproject.github.io/ecvl/).
+The ECVL documentation is available [here](https://deephealthproject.github.io/ecvl/).
 
 ## Requirements
 - CMake 3.13 or later

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Documentation
 
-The ECVL documentation is available online [here](https://deephealthproject.github.io/ecvl/).
+The ECVL documentation is available [here](https://deephealthproject.github.io/ecvl/).
 
 ## Requirements
 - CMake 3.13 or later
@@ -76,70 +76,15 @@ make install
 
 An extension of ImageWatch is available to visually inspect ecvl::Image when debugging. In order to use it be sure to install the ImageWatch plugin for Visual Studio and copy and past the file ```tools/ECVL.natvis``` from the GitHub repo into ```C:\Users\<!!username!!>\Documents\Visual Studio 2017\Visualizers```
 
-## ECVL Development Status (Work in progress list)
+## ECVL Development Status
 
-:heavy_check_mark: Implemented &nbsp; &nbsp; :large_blue_circle: Scheduled/Work in progress &nbsp; &nbsp; :x: Not implemented &nbsp; &nbsp; :no_entry_sign: Not needed
+ECVL development status is available [here](DEVSTAT.md).
 
-### Image Read
-| Functionality | CPU | GPU | FPGA |
-|--|--|--|--|
-| Standard Formats | :heavy_check_mark: | :x: | :x: |
-| NIfTI | :heavy_check_mark: | :x: | :x: |
-| DICOM | :heavy_check_mark: | :x: | :x: |
-| Whole-slide image <br>(Hamamatsu, Aperio, MIRAX, ...) | :heavy_check_mark: | :x: | :x: |
+## Contributing
 
-### Image Write
-| Functionality | CPU | GPU | FPGA |
-|--|--|--|--|
-| Standard Formats | :heavy_check_mark: | :x: | :x: |
-| NIfTI | :heavy_check_mark: | :x: | :x: |
-| DICOM | :heavy_check_mark: | :x: | :x: |
+Any contribution is really welcome!
 
-### Image Arithmetics
-| Functionality | CPU | GPU | FPGA |
-|--|--|--|--|
-| Add | :heavy_check_mark: | :x: | :x: |
-| Sub | :heavy_check_mark: | :x: | :x: |
-| Mul | :heavy_check_mark: | :x: | :x: |
-| Div | :heavy_check_mark: | :x: | :x: |
-| Neg | :heavy_check_mark: | :x: | :x: |
+## Contributors ✨
 
-### Image Manipulation
-| Functionality | CPU | GPU | FPGA |
-|--|--|--|--|
-| ChangeColorSpace | :heavy_check_mark: | :x: | :x: |
-| Flip | :heavy_check_mark: | :x: | :x: |
-| HConcat | :heavy_check_mark: | :x: | :x: |
-| Mirror | :heavy_check_mark: | :x: | :x: |
-| ResizeDim | :heavy_check_mark: | :x: | :x: |
-| ResizeScale | :heavy_check_mark: | :x: | :x: |
-| Rotate | :heavy_check_mark: | :x: | :x: |
-| RotateFullImage | :heavy_check_mark: | :x: | :x: |
-| Stack | :heavy_check_mark: | :x: | :x: |
-| VConcat | :heavy_check_mark: | :x: | :x: |
+The [Emoji Contribution Key](https://allcontributors.org/docs/en/emoji-key) can be found on [allcontributors.org](https://allcontributors.org)
 
-### Pre- Post-processing and Augmentation
-| Functionality | CPU | GPU | FPGA |
-|--|--|--|--|
-| Additive Gaussian Noise | :x: | :x: | :x: |
-| Additive Laplace Noise | :heavy_check_mark: | :x: | :x: |
-| Additive Poisson Noise | :heavy_check_mark: | :x: | :x: |
-| Average Blur | :x: | :x: | :x: |
-| Channel Shuffle | :x: | :x: | :x: |
-| Coarse Dropout | :heavy_check_mark: | :x: | :x: |
-| Connected Components Labeling | :heavy_check_mark: | :x: | :x: |
-| Dropout | :x: | :x: | :x: |
-| Filter2D | :heavy_check_mark: | :x: | :x: |
-| FindContours | :heavy_check_mark: | :x: | :x: |
-| Gamma Contrast | :heavy_check_mark: | :x: | :x: |
-| Gaussian Blur | :heavy_check_mark: | :x: | :x: |
-| Histogram Equalization | :x: | :x: | :x: |
-| Impulse Noise | :x: | :x: | :x: |
-| Integral Image | :heavy_check_mark: | :x: | :x: |
-| Median Blur | :x: | :x: | :x: |
-| Non Maxima Suppression | :heavy_check_mark: | :x: | :x: |
-| Pepper | :x: | :x: | :x: |
-| Salt | :x: | :x: | :x: |
-| Salt And Pepper | :x: | :x: | :x: |
-| SeparableFilter2D | :heavy_check_mark: | :x: | :x: |
-| Threshold | :heavy_check_mark: | :x: | :x: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  token: 7635bd2e-51cf-461e-bb1b-fc7ba9fb26d1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  token: 7635bd2e-51cf-461e-bb1b-fc7ba9fb26d1


### PR DESCRIPTION
This pull request configures Jenkins to calculate code coverage using both cobertura and codecov, configures the "all-contributors" bot to automatically add contributors to the README.md of the project. Multiple badges have been also added.