### PR TITLE
Make c++ filesystem library portable

### DIFF
--- a/examples/example_dataset_generator.cpp
+++ b/examples/example_dataset_generator.cpp
@@ -12,14 +12,14 @@
 */
 
 #include "ecvl/core.h"
+#include "ecvl/core/filesystem.h"
 #include "ecvl/dataset_generator.h"
 
-#include <filesystem>
 #include <iostream>
 
 using namespace std;
 using namespace ecvl;
-using namespace std::filesystem;
+using namespace fs;
 
 int main()
 {

--- a/examples/example_dataset_parser.cpp
+++ b/examples/example_dataset_parser.cpp
@@ -12,17 +12,18 @@
 */
 
 #include "ecvl/core.h"
+#include "ecvl/core/filesystem.h"
 #include "ecvl/dataset_parser.h"
 
-#include <filesystem>
 #include <iostream>
 
 using std::cout;
 using std::endl;
+using fs::path;
 
 int main()
 {
-    std::filesystem::path file = "../examples/data/mnist/mnist.yml";
+    path file = "../examples/data/mnist/mnist.yml";
     cout << "Reading Dataset from " << file << " file" << endl;
     ecvl::Dataset d(file);
 

--- a/modules/core/include/ecvl/CMakeLists.txt
+++ b/modules/core/include/ecvl/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(ECVL_CORE
     core/datatype_existing_tuples_unsigned.inc.h
     core/datatype_matrix.h
     core/datatype_tuples.inc.h
+    core/filesystem.h
     core/fpga_hal.h
     core/hal.h
     core/image.h

--- a/modules/core/include/ecvl/core/filesystem.h
+++ b/modules/core/include/ecvl/core/filesystem.h
@@ -1,0 +1,80 @@
+/*
+* ECVL - European Computer Vision Library
+* Version: 0.2.1
+* copyright (c) 2020, Università degli Studi di Modena e Reggio Emilia (UNIMORE), AImageLab
+* Authors:
+*    Costantino Grana (costantino.grana@unimore.it)
+*    Federico Bolelli (federico.bolelli@unimore.it)
+*    Michele Cancilla (michele.cancilla@unimore.it)
+*    Laura Canalini (laura.canalini@unimore.it)
+*    Stefano Allegretti (stefano.allegretti@unimore.it)
+* All rights reserved.
+*/
+
+// https://github.com/bugstop/vmware-macos-unlocker/blob/master/auto-unlocker/include/filesystem.hpp
+
+// We haven't checked which filesystem to include yet
+#ifndef INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+
+// Check for feature test macro for <filesystem>
+#   if defined(__cpp_lib_filesystem)
+#       define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+
+// Check for feature test macro for <experimental/filesystem>
+#   elif defined(__cpp_lib_experimental_filesystem)
+#       define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// We can't check if headers exist...
+// Let's assume experimental to be safe
+#   elif !defined(__has_include)
+#       define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Check if the header "<filesystem>" exists
+#   elif __has_include(<filesystem>)
+
+// If we're compiling on Visual Studio and are not compiling with C++17, we need to use experimental
+#       ifdef _MSC_VER
+
+// Check and include header that defines "_HAS_CXX17"
+#           if __has_include(<yvals_core.h>)
+#               include <yvals_core.h>
+
+// Check for enabled C++17 support
+#               if defined(_HAS_CXX17) && _HAS_CXX17
+// We're using C++17, so let's use the normal version
+#                   define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+#               endif
+#           endif
+
+// If the macro isn't defined yet, that means any of the other VS specific checks failed, so we need to use experimental
+#           ifndef INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+#               define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+#           endif
+
+// Not on Visual Studio. Let's use the normal version
+#       else // #ifdef _MSC_VER
+#           define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+#       endif
+
+// Check if the header "<filesystem>" exists
+#   elif __has_include(<experimental/filesystem>)
+#       define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Fail if neither header is available with a nice error message
+#   else
+#       error Could not find system header "<filesystem>" or "<experimental/filesystem>"
+#   endif
+
+// We previously determined that we need the experimental version
+#   if INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+// Include it
+#       include <experimental/filesystem>
+// We need the alias from std::experimental::filesystem to std::filesystem
+namespace fs = std::experimental::filesystem;
+#   else
+#       include <filesystem>
+namespace fs = std::filesystem;
+
+#   endif
+
+#endif // #ifndef INCLUDE_STD_FILESYSTEM_EXPERIMENTAL

--- a/modules/core/include/ecvl/core/image.h
+++ b/modules/core/include/ecvl/core/image.h
@@ -460,13 +460,16 @@ public:
     /** @brief Returns the number of channels. */
     int Channels() const
     {
-        if (size_t c = channels_.find('c'); c != std::string::npos) {
+        size_t c = channels_.find('c');
+        if (c != std::string::npos) {
             return dims_[c];
         }
-        if (size_t c = channels_.find('z'); c != std::string::npos) {
+        c = channels_.find('z');
+        if (c != std::string::npos) {
             return dims_[c];
         }
-        if (size_t c = channels_.find('o'); c != std::string::npos) {
+        c = channels_.find('o');
+        if (c != std::string::npos) {
             return dims_[c];
         }
         return 0;
@@ -475,7 +478,8 @@ public:
     /** @brief Returns the width of Image. */
     int Width() const
     {
-        if (size_t x = channels_.find('x'); x != std::string::npos) {
+        size_t x = channels_.find('x');
+        if (x != std::string::npos) {
             return dims_[x];
         }
         return 0;
@@ -484,7 +488,8 @@ public:
     /** @brief Returns the height of Image. */
     int Height() const
     {
-        if (size_t y = channels_.find('y'); y != std::string::npos) {
+        size_t y = channels_.find('y');
+        if (y != std::string::npos) {
             return dims_[y];
         }
         return 0;

--- a/modules/core/include/ecvl/core/imgcodecs.h
+++ b/modules/core/include/ecvl/core/imgcodecs.h
@@ -14,11 +14,11 @@
 #ifndef ECVL_IMGCODECS_H_
 #define ECVL_IMGCODECS_H_
 
-#include <filesystem>
+#include "ecvl/core/filesystem.h"
 #include <string>
 
-#include "image.h"
 
+#include "image.h"
 namespace ecvl {
 /** @brief Enum class representing the ECVL ImRead flags.
 
@@ -45,7 +45,7 @@ be read for any reason, the function creates an empty Image and returns false.
 
 @return true if the image is correctly read, false otherwise.
 */
-bool ImRead(const std::filesystem::path& filename, Image& dst, ImReadMode flags = ImReadMode::COLOR);
+bool ImRead(const fs::path& filename, Image& dst, ImReadMode flags = ImReadMode::COLOR);
 
 /** @brief Loads a multi-page image from a file.
 
@@ -57,7 +57,7 @@ be read for any reason, the function creates an empty Image and returns false.
 
 @return true if the image is correctly read, false otherwise.
 */
-bool ImReadMulti(const std::filesystem::path& filename, Image& dst);
+bool ImReadMulti(const fs::path& filename, Image& dst);
 
 /** @brief Saves an image into a specified file.
 
@@ -72,7 +72,7 @@ filename extension. The following sample shows how to create a BGR image and sav
 
 @return true if the image is correctly written, false otherwise.
 */
-bool ImWrite(const std::filesystem::path& filename, const Image& src);
+bool ImWrite(const fs::path& filename, const Image& src);
 
 /** @example example_imgcodecs.cpp
  Imgcodecs example.

--- a/modules/core/include/ecvl/core/support_nifti.h
+++ b/modules/core/include/ecvl/core/support_nifti.h
@@ -14,8 +14,8 @@
 #ifndef ECVL_SUPPORT_NIFTI_H_
 #define ECVL_SUPPORT_NIFTI_H_
 
+#include "filesystem.h"
 #include "image.h"
-#include <filesystem>
 
 namespace ecvl {
 
@@ -31,7 +31,7 @@ be read for any reason, the function creates an empty Image and returns false.
 
 @return true if the image is correctly read, false otherwise.
 */
-bool NiftiRead(const std::filesystem::path& filename, Image& dst);
+bool NiftiRead(const fs::path& filename, Image& dst);
 
 /** @brief Saves an image into a specified nifti file.
 
@@ -44,7 +44,7 @@ The function NiftiWrite saves the input image into a specified file, with the NI
 
 @return true if the image is correctly written, false otherwise.
 */
-bool NiftiWrite(const std::filesystem::path& filename, const Image& src);
+bool NiftiWrite(const fs::path& filename, const Image& src);
 } // namespace ecvl 
 
 #endif // ECVL_SUPPORT_NIFTI_H_

--- a/modules/core/src/imgcodecs.cpp
+++ b/modules/core/src/imgcodecs.cpp
@@ -16,6 +16,7 @@
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
 
+#include "ecvl/core/filesystem.h"
 #include "ecvl/core/support_nifti.h"
 #include "ecvl/core/support_opencv.h"
 
@@ -23,7 +24,7 @@
 #include "ecvl/core/support_dcmtk.h"
 #endif
 
-using namespace std::filesystem;
+using namespace fs;
 
 namespace ecvl
 {

--- a/modules/core/src/support_nifti.cpp
+++ b/modules/core/src/support_nifti.cpp
@@ -16,10 +16,11 @@
 #include <fstream>
 #include <string>
 
+#include "ecvl/core/filesystem.h"
 #include "ecvl/core/standard_errors.h"
 
 using namespace std;
-using namespace std::filesystem;
+using namespace fs;
 
 namespace ecvl
 {

--- a/modules/dataset/include/ecvl/dataset_generator.h
+++ b/modules/dataset/include/ecvl/dataset_generator.h
@@ -14,8 +14,8 @@
 #ifndef ECVL_DATASET_GENERATOR_H_
 #define ECVL_DATASET_GENERATOR_H_
 
+#include <ecvl/core/filesystem.h>
 #include <ecvl/dataset_parser.h>
-#include <filesystem>
 
 namespace ecvl
 {
@@ -26,19 +26,19 @@ namespace ecvl
 class GenerateDataset
 {
 public:
-    const std::filesystem::path dataset_root_directory_;    /**< @brief path containing the root directory of the dataset */
-    std::vector<std::string> splits_;                       /**< @brief vector containing the splits found in the dataset directory, if present */
-    std::vector<int> num_samples_;                          /**< @brief vector containing the number of samples for each split*/
-    ecvl::Dataset d_;                                       /**< @brief Dataset object to fill */
+    const fs::path dataset_root_directory_;  /**< @brief path containing the root directory of the dataset */
+    std::vector<std::string> splits_;        /**< @brief vector containing the splits found in the dataset directory, if present */
+    std::vector<int> num_samples_;           /**< @brief vector containing the number of samples for each split*/
+    ecvl::Dataset d_;                        /**< @brief Dataset object to fill */
 
     /** @brief GenerateDataset constructor
 
     @param[in] dataset_root_directory path containing the root directory of the dataset.
     */
-    GenerateDataset(const std::filesystem::path& dataset_root_directory) :
+    GenerateDataset(const fs::path& dataset_root_directory) :
         dataset_root_directory_(dataset_root_directory)
     {
-        for (auto& p : std::filesystem::directory_iterator(dataset_root_directory_)) {
+        for (auto& p : fs::directory_iterator(dataset_root_directory_)) {
             std::string tmp = p.path().stem().string();
 
             // Check if split folders exist
@@ -71,7 +71,7 @@ public:
     @param[in] split directory name of the split that we are considering.
     @return The number of samples of the split.
     */
-    virtual int LoadSplitImages(const std::filesystem::path& split) = 0;
+    virtual int LoadSplitImages(const fs::path& split) = 0;
 };
 
 /** @brief Generate an ecvl::Dataset from a directory tree for a segmentation task.
@@ -88,17 +88,17 @@ For more detailed information about the supported directory structure check http
 class GenerateSegmentationDataset : public GenerateDataset
 {
 public:
-    std::filesystem::path suffix_;  /**< @brief path containing the suffix or extension of ground truth images */
-    std::filesystem::path gt_name_; /**< @brief path containing the ground truth name for images that share the same ground truth */
+    fs::path suffix_;  /**< @brief path containing the suffix or extension of ground truth images */
+    fs::path gt_name_; /**< @brief path containing the ground truth name for images that share the same ground truth */
 
     /** @brief GenerateSegmentationDataset constructor
 
     @param[in] dataset_root_directory path containing the root directory of the dataset.
     @param[in] suffix suffix or extension of ground truth images, necessary if it's different from corresponding images (e.g., "_segmentation.png" or ".png").
-    @param[in] gt_name name of the ground truth for images that share the same ground truth. 
+    @param[in] gt_name name of the ground truth for images that share the same ground truth.
                        All images in the split (if available) which don't have their own ground truth will use this one.
     */
-    GenerateSegmentationDataset(const std::filesystem::path& dataset_root_directory, std::filesystem::path suffix = "", std::filesystem::path gt_name = "") :
+    GenerateSegmentationDataset(const fs::path& dataset_root_directory, fs::path suffix = "", fs::path gt_name = "") :
         GenerateDataset{ dataset_root_directory },
         suffix_{ suffix },
         gt_name_{ gt_name }
@@ -106,7 +106,7 @@ public:
         LoadImagesAndSplits();
     }
 
-    virtual int LoadSplitImages(const std::filesystem::path& split) override;
+    virtual int LoadSplitImages(const fs::path& split) override;
 };
 
 /** @brief Generate an ecvl::Dataset from a directory tree for a classification task.
@@ -128,9 +128,9 @@ public:
 
     @param[in] dataset_root_directory path containing the root directory of the dataset.
     */
-    GenerateClassificationDataset(const std::filesystem::path& dataset_root_directory) : GenerateDataset{ dataset_root_directory }
+    GenerateClassificationDataset(const fs::path& dataset_root_directory) : GenerateDataset{ dataset_root_directory }
     {
-        std::filesystem::path tmp;
+        fs::path tmp;
 
         if (splits_.empty()) {
             tmp = dataset_root_directory_;
@@ -140,8 +140,8 @@ public:
             tmp = dataset_root_directory_ / splits_[0];
         }
 
-        for (auto& p : std::filesystem::directory_iterator(tmp)) {
-            if (std::filesystem::is_directory(p.path())) {
+        for (auto& p : fs::directory_iterator(tmp)) {
+            if (fs::is_directory(p.path())) {
                 d_.classes_.push_back(p.path().stem().string());
             }
         }
@@ -149,7 +149,7 @@ public:
         LoadImagesAndSplits();
     }
 
-    virtual int LoadSplitImages(const std::filesystem::path& split) override;
+    virtual int LoadSplitImages(const fs::path& split) override;
 };
 } // namespace ecvl
 

--- a/modules/dataset/include/ecvl/dataset_parser.h
+++ b/modules/dataset/include/ecvl/dataset_parser.h
@@ -15,8 +15,8 @@
 #define ECVL_DATASET_PARSER_H_
 
 #include "ecvl/core.h"
+#include "ecvl/core/filesystem.h"
 
-#include <filesystem>
 #include <iostream>
 #include <map>
 #include <optional>
@@ -45,9 +45,9 @@ This class provides the information to describe a dataset sample.
 class Sample
 {
 public:
-    std::vector<std::filesystem::path> location_; /**< @brief Absolute path of the sample. */
+    std::vector<fs::path> location_; /**< @brief Absolute path of the sample. */
     std::optional<std::vector<int>> label_; /**< @brief Vector of sample labels. */
-    std::optional<std::filesystem::path> label_path_; /**< @brief Absolute path of sample ground truth. */
+    std::optional<fs::path> label_path_; /**< @brief Absolute path of sample ground truth. */
     std::optional<std::map<int, std::string>> values_; /**< @brief Map (`map<feature-index,feature-value>`) which stores the features of a sample. */
     std::vector<int> size_; /**< @brief Original x and y dimensions of the sample */
 
@@ -98,7 +98,7 @@ public:
     /**
     @param[in] filename Path to the Dataset file.
     */
-    Dataset(const std::filesystem::path& filename, bool verify = false);
+    Dataset(const fs::path& filename, bool verify = false);
 
     /** @brief Dump the Dataset into a YAML file following the DeepHealth Dataset Format.
 
@@ -107,14 +107,14 @@ public:
 
     @param[in] file_path Where to save the YAML file.
     */
-    void Dump(const std::filesystem::path& file_path);
+    void Dump(const fs::path& file_path);
 
     // RegEx which matchs URLs
     static const std::regex url_regex_;
 
 private:
     std::map<std::string, int> features_map_;
-    void DecodeImages(const YAML::Node& node, const std::filesystem::path& root_path, bool verify);
+    void DecodeImages(const YAML::Node& node, const fs::path& root_path, bool verify);
     void FindLabel(Sample& sample, const YAML::Node& n);
 };
 } // namespace ecvl

--- a/modules/dataset/src/dataset_generator.cpp
+++ b/modules/dataset/src/dataset_generator.cpp
@@ -11,12 +11,14 @@
 * All rights reserved.
 */
 
+#include "ecvl/core/filesystem.h"
 #include "ecvl/dataset_generator.h"
+
 #include <iostream>
 #include <optional>
 
 using namespace std;
-using namespace std::filesystem;
+using namespace fs;
 using namespace ecvl;
 
 int GenerateClassificationDataset::LoadSplitImages(const path& split)

--- a/modules/dataset/src/dataset_parser.cpp
+++ b/modules/dataset/src/dataset_parser.cpp
@@ -11,13 +11,16 @@
 * All rights reserved.
 */
 
+#include "ecvl/core/filesystem.h"
 #include "ecvl/dataset_parser.h"
+
 #include <fstream>
 #include <regex>
 
 using namespace std;
-using namespace std::filesystem;
+using namespace fs;
 using namespace YAML;
+
 namespace ecvl
 {
 const std::regex Dataset::url_regex_ = std::regex{ R"(https?://.*)" };

--- a/modules/eddl/include/ecvl/support_eddl.h
+++ b/modules/eddl/include/ecvl/support_eddl.h
@@ -18,6 +18,7 @@
 #include <eddl/apis/eddlT.h>
 #include "ecvl/augmentations.h"
 #include "ecvl/core/image.h"
+#include "ecvl/core/filesystem.h"
 #include "ecvl/dataset_parser.h"
 
 namespace ecvl
@@ -78,7 +79,7 @@ public:
     @param[in] ctype_gt ecvl::ColorType of the Dataset ground truth images.
     @param[in] verify If true, a list of all the images in the Dataset file which don't exist is printed with an ECVL_WARNING_MSG.
     */
-    DLDataset(const std::filesystem::path& filename,
+    DLDataset(const fs::path& filename,
         const int batch_size,
         DatasetAugmentations augs = DatasetAugmentations(),
         ColorType ctype = ColorType::BGR,

--- a/modules/eddl/src/support_eddl.cpp
+++ b/modules/eddl/src/support_eddl.cpp
@@ -13,15 +13,15 @@
 
 #include <ecvl/support_eddl.h>
 
-#include "ecvl/core/imgproc.h"
+#include "ecvl/core/filesystem.h"
 #include "ecvl/core/imgcodecs.h"
+#include "ecvl/core/imgproc.h"
 #include "ecvl/core/standard_errors.h"
 
-#include <filesystem>
 #include <iostream>
 
 using namespace eddl;
-using namespace std::filesystem;
+using namespace fs;
 
 namespace ecvl
 {


### PR DESCRIPTION
This PR adds a filesystem.h header file which choose whether to use  `std::experimental::filesystem` or `std::filesystem`.

ECVL should allow support for compilers with limited C++-17 support, such as GCC-6 and GCC-7.