### PR TITLE
Add missing include

### DIFF
--- a/modules/core/src/cpu_hal_imgproc.cpp
+++ b/modules/core/src/cpu_hal_imgproc.cpp
@@ -14,6 +14,7 @@
 #include "ecvl/core/cpu_hal.h"
 
 #include <random>
+#include <functional>
 #include <opencv2/photo.hpp>
 
 #if OpenCV_VERSION_MAJOR >= 4


### PR DESCRIPTION
I got this error while trying to build ECVL 0.2.2:

```
/ecvl/modules/core/src/cpu_hal_imgproc.cpp:1711:21: error: 'function' is not a member of 'std'
     auto color(std::function<int()>([]() { return 255; }));
                     ^~~~~~~~
/ecvl/modules/core/src/cpu_hal_imgproc.cpp:1711:21: note: suggested alternative: 'is_function'
     auto color(std::function<int()>([]() { return 255; }));
                     ^~~~~~~~
                     is_function
```

This PR fixes it.

It's a bit weird that your builds pass despite this. One difference is that I'm building with opencv 3.2.0. Maybe more recent opencv versions include `functional` somewhere, thus masking this problem.