### PR TITLE
Fix vector dim check in Normalize

### DIFF
--- a/modules/core/src/imgproc.cpp
+++ b/modules/core/src/imgproc.cpp
@@ -702,8 +702,8 @@ void Normalize(const Image& src, Image& dst, const vector<double>& mean, const v
 {
     AlwaysCheck(src, dst);
 
-    if (src.dims_.size() != mean.size() || src.dims_.size() != std.size()) {
-        ECVL_ERROR_WRONG_PARAMS("mean and std have different sizes from src.dims_")
+    if (src.channels_.size() != mean.size() || src.channels_.size() != std.size()) {
+        ECVL_ERROR_WRONG_PARAMS("mean and std have different sizes from src.channels_")
     }
 
     return src.hal_->Normalize(src, dst, mean, std);

--- a/modules/core/src/imgproc.cpp
+++ b/modules/core/src/imgproc.cpp
@@ -702,8 +702,9 @@ void Normalize(const Image& src, Image& dst, const vector<double>& mean, const v
 {
     AlwaysCheck(src, dst);
 
-    if (src.channels_.size() != mean.size() || src.channels_.size() != std.size()) {
-        ECVL_ERROR_WRONG_PARAMS("mean and std have different sizes from src.channels_")
+    const int n_channels = src.Channels();
+    if (n_channels != mean.size() || n_channels != std.size()) {
+        ECVL_ERROR_WRONG_PARAMS("mean or std size is not equal to the number of channels")
     }
 
     return src.hal_->Normalize(src, dst, mean, std);

--- a/modules/core/test/test_imgproc.cpp
+++ b/modules/core/test/test_imgproc.cpp
@@ -750,6 +750,7 @@ TEST_F(Imgproc, NormalizeChannels##type) \
     EXPECT_TRUE(out_v({ 1,0,2 }) == saturate_cast<TypeInfo_t<DataType::type>>((rgb2_##type##_v({ 1,0,2 }) - mean[2]) / std[2])); \
     EXPECT_TRUE(out_v({ 0,1,2 }) == saturate_cast<TypeInfo_t<DataType::type>>((rgb2_##type##_v({ 0,1,2 }) - mean[2]) / std[2])); \
     EXPECT_TRUE(out_v({ 1,1,2 }) == saturate_cast<TypeInfo_t<DataType::type>>((rgb2_##type##_v({ 1,1,2 }) - mean[2]) / std[2])); \
+    EXPECT_THROW(Normalize(g2_##type, out, mean, std), std::runtime_error); \
 } \
 \
 TEST_F(Imgproc, CenterCrop##type) \


### PR DESCRIPTION
Fixes the dimension check in `Normalize` (compare `mean` and `std` with the number of channels rather than the number of image dimensions).

BTW, I've noticed that `Normalize(src, dst, {0.8}, {0.1})` calls `Normalize(const Image&, Image&, const double&, const double&)` rather than the vector version, due to list initialization semantics. Is this intended?