### PR TITLE
DLDataset::GetBatch: use shared_ptr

### DIFF
--- a/examples/example_pipeline.cpp
+++ b/examples/example_pipeline.cpp
@@ -82,7 +82,7 @@ int main()
             cout << "Epoch " << i << "/" << epochs - 1 << " (batch " << j << "/" << num_batches_training - 1 << ") - ";
             cout << "|fifo| " << d.GetQueueSize() << " - ";
 
-            // tuple<vector<Sample>, unique_ptr<Tensor>, unique_ptr<Tensor>> samples_and_labels;
+            // tuple<vector<Sample>, shared_ptr<Tensor>, shared_ptr<Tensor>> samples_and_labels;
             // samples_and_labels = d.GetBatch();
             // or...
             auto [samples, x, y] = d.GetBatch();
@@ -110,7 +110,7 @@ int main()
             cout << "Test: Epoch " << i << "/" << epochs - 1 << " (batch " << j << "/" << num_batches_test - 1 << ") - ";
             cout << "|fifo| " << d.GetQueueSize() << " - ";
 
-            // tuple<vector<Sample>, unique_ptr<Tensor>, unique_ptr<Tensor>> samples_and_labels;
+            // tuple<vector<Sample>, shared_ptr<Tensor>, shared_ptr<Tensor>> samples_and_labels;
             // samples_and_labels = d.GetBatch();
             // or...
             auto [_, x, y] = d.GetBatch();

--- a/modules/eddl/include/ecvl/support_eddl.h
+++ b/modules/eddl/include/ecvl/support_eddl.h
@@ -522,7 +522,7 @@ public:
 
     @return tuples of Samples and EDDL Tensors, the first with the image and the second with the label.
     */
-    std::tuple<std::vector<Sample>, unique_ptr<Tensor>, unique_ptr<Tensor>> GetBatch();
+    std::tuple<std::vector<Sample>, shared_ptr<Tensor>, shared_ptr<Tensor>> GetBatch();
 
     /** @brief Spawn num_workers thread.
 

--- a/modules/eddl/src/support_eddl.cpp
+++ b/modules/eddl/src/support_eddl.cpp
@@ -422,7 +422,7 @@ void DLDataset::ThreadFunc(int thread_index)
     }
 }
 
-tuple<vector<Sample>, unique_ptr<Tensor>, unique_ptr<Tensor>> DLDataset::GetBatch()
+tuple<vector<Sample>, shared_ptr<Tensor>, shared_ptr<Tensor>> DLDataset::GetBatch()
 {
     if (!active_) {
         cout << ECVL_WARNING_MSG << "You're trying to get a batch without starting the threads - you'll wait forever!" << endl;
@@ -443,8 +443,8 @@ tuple<vector<Sample>, unique_ptr<Tensor>, unique_ptr<Tensor>> DLDataset::GetBatc
     // If current split has no labels (e.g., test split could have no labels) set y as empty tensor
     tensors_shape.second = (s.no_label_) ? vector<int>{} : tensors_shape.second;
 
-    unique_ptr<Tensor> x = make_unique<Tensor>(tensors_shape.first);
-    unique_ptr<Tensor> y = make_unique<Tensor>(tensors_shape.second);
+    shared_ptr<Tensor> x = make_shared<Tensor>(tensors_shape.first);
+    shared_ptr<Tensor> y = make_shared<Tensor>(tensors_shape.second);
 
     const int batch_len = x->shape[0];
     Image img;


### PR DESCRIPTION
This PR makes life easier for the Python bindings.

The current binding for `GetBatch` is:

```cpp
  cl.def("GetBatch", [](ecvl::DLDataset& d) -> pybind11::tuple {
    auto [samples, x_u, y_u] = d.GetBatch();
    std::shared_ptr<Tensor> x = std::move(x_u);
    std::shared_ptr<Tensor> y = std::move(y_u);
    return pybind11::make_tuple(samples, x, y);
  });
```

With this PR, the binding can simply be written as:

```cpp
  cl.def("GetBatch", &ecvl::DLDataset::GetBatch);
```

I.e., it works out of the box, since it's directly supported by Pybind11.

Note that the above workaround works because `unique_ptr` can be converted to `shared_ptr`. However, the opposite is not possible, so any functions or methods that take a `unique_ptr` as an argument would be **impossible to bind**. So please avoid using unique pointers across the board :slightly_smiling_face: 

Ref: https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#std-unique-ptr