### PR TITLE
Add missing include

### DIFF
--- a/modules/core/include/ecvl/core/metadata.h
+++ b/modules/core/include/ecvl/core/metadata.h
@@ -14,6 +14,7 @@
 #ifndef ECVL_METADATA_H_
 #define ECVL_METADATA_H_
 
+#include <functional>
 #include <typeindex>
 #include <unordered_map>
 #include "ecvl/core/any.h"


### PR DESCRIPTION
Adds a missing include to `metadata.h`