### PR TITLE
Ensure all batches are reset

### DIFF
--- a/modules/eddl/include/ecvl/support_eddl.h
+++ b/modules/eddl/include/ecvl/support_eddl.h
@@ -177,6 +177,19 @@ public:
         cond_notempty_.notify_one();
     }
 
+    /** @brief Free threads locked on a push operation.
+
+    Notifies all the locked threads on the condition variable cond_notfull_ that were waiting to retake the control in the
+    critical region of pushing new elements in to the queue.
+
+    This method is specific to be used in the Stop() operation when the data loading process needs to be stopped before all
+    the elements (batches) of the queue have been consumed.
+    */
+    void FreeLockedOnPush()
+    {
+        cond_notfull_.notify_all();
+    }
+
     /** @brief Pop a sample from the queue.
 
     Take the lock of the queue and wait if the queue is empty. Otherwise, pop a sample, an image and its label from the queue.

--- a/modules/eddl/src/support_eddl.cpp
+++ b/modules/eddl/src/support_eddl.cpp
@@ -518,7 +518,12 @@ void DLDataset::Stop()
         ECVL_ERROR_STOP_ALREADY_END
     }
 
-    active_ = false;
+    {
+        std::unique_lock<std::mutex> lock(active_mutex_);
+        active_ = false;
+        queue_.FreeLockedOnPush();
+    }
+
     for (auto i = 0u; i < num_workers_; ++i) {
         producers_[i].join();
     }


### PR DESCRIPTION
... when a split is reused.